### PR TITLE
chore: make repository public

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Github actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "NicoFgrx"

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -6,35 +6,79 @@ on:
       PLUGIN_VERSION:
         description: 'CTFd-chall-manager version'
         required: true
-        default: '0.2.0'
       CTFD_VERSION:
         description: 'CTFd version'
         required: true
-        default: '3.7.5'
+
+permissions:
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (labels) for Docker
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ctferio/ctfd
+
+      - name: Git commit date
+        id: infos
+        run: |
+          # trim version prefix
+          version=${{ github.ref_name }}
+          version="${version#"v"}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          # output date per RFC 3339
+          date="$(git log -1 --format=%cd --date=format:%Y-%m-%dT%H:%M:%SZ)"
+          echo "date=$date" >> "$GITHUB_OUTPUT"
 
       - name: Build Docker image
-        uses: docker/build-push-action@67a2d409c0a876cbe6b11854e3e25193efe4e62d # v6.12.0
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        id: build
         with:
           context: .
           push: true
+          sbom: true # may not produce SBOM in manifest if the image has no filesystem (e.g. "FROM scratch")
           tags: ctferio/ctfd:${{ inputs.CTFD_VERSION }}-${{ inputs.PLUGIN_VERSION }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             PLUGIN_VERSION=${{ inputs.PLUGIN_VERSION }}
             CTFD_VERSION=${{ inputs.CTFD_VERSION }}
+
+  # This step calls the container workflow to generate provenance and push it to
+  # the container registry.
+  provenance-cm:
+    needs: [build]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: ctferio/chall-manager
+      digest: ${{ needs.build.outputs.digest }}
+    secrets:
+      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/scoreboard.yaml
+++ b/.github/workflows/scoreboard.yaml
@@ -1,0 +1,35 @@
+name: Scorecard supply-chain security
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 6 * * 6'
+  push:
+    branches: [ "main" ]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
+        with:
+          sarif_file: results.sarif

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+ctfer-io@protonmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,39 @@
-# CTFd-packaged
+<div align="center">
+    <h1>CTFd-packaged</h1>
+    <a href=""><img src="https://img.shields.io/github/license/ctfer-io/ctfd-packaged?style=for-the-badge" alt="License"></a>
+    <a href="https://securityscorecards.dev/viewer/?uri=github.com/ctfer-io/ctfd-packaged"><img src="https://img.shields.io/ossf-scorecard/github.com/ctfer-io/ctfd-packaged?label=openssf%20scorecard&style=for-the-badge" alt="OpenSSF Scoreboard"></a>
+</div>
 
-Prepackaged CTFd with CTFd-chall-manager plugin
+This repository is an internal tool to generate pre-packaged versions of CTFd.
+
+Actually, it is used to publish the Docker image [`ctferio/ctfd`](https://hub.docker.com/r/ctferio/ctfd).
+This image integrate our work for direct reuse, plus fits our security policies regarding traceability and auditability regarding Software Supply Chain.
+
+It contains:
+- [CTFd](https://github.com/ctfd/ctfd)
+- [CTFd-Chall-Manager](http://github.com/ctfer-io/ctfd-chall-manager)
+
+## Security
+
+### Signature and Attestations
+
+For deployment purposes (and especially in the deployment case of Kubernetes), you may want to ensure the integrity of what you run.
+
+The Docker image is SLSA 3 and can be verified using [slsa-verifier](https://github.com/slsa-framework/slsa-verifier) using the following.
+
+```bash
+slsa-verifier slsa-verifier verify-image "ctferio/ctfd:<tag>@sha256:<digest>" \
+    --source-uri "github.com/ctfer-io/ctfd" \
+    --source-tag "<tag>"
+```
+
+Alternatives exist, like [Kyverno](https://kyverno.io/) for a Kubernetes-based deployment.
+
+### SBOMs
+
+A SBOM is generated for the Docker image in its manifest, and can be inspected using the following.
+
+```bash
+docker buildx imagetools inspect "ctferio/ctfd:<tag>" \
+    --format "{{ json .SBOM.SPDX }}"
+```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Reporting Security Issues
+
+Please report any security issues you discovered in the prepackaged CTFd to ctfer-io@protonmail.com.
+
+We will assess the risk, plus make a fix available before we create a GitHub issue.
+
+In case the vulnerability is into a dependency, please refer to their security policy directly.
+- [CTFd](https://github.com/CTFd/CTFd/securit)
+- [ctfd-chall-manager](https://github.com/ctfer-io/ctfd-chall-manager/blob/main/SECURITY.md)
+
+Thank you for your contribution.
+
+## Refering to this repository
+
+To refer to this repository using a CPE v2.3, please use respectively:
+- `ctferio/ctfd`: `cpe:2.3:a:ctfer-io:ctfd:*:*:*:*:*:*:*:*`
+
+Use with the `version` set to the tag you are using.


### PR DESCRIPTION
In this PR I propose to make this repository public for auditability thus trust from the community.

Regarding the security of publishing the GitHub Action `workflow_dispatch`, no member outside of the organization and without write access can trigger the workflow, guarding an external collaborator to use [ctfer-io-bot](https://github.com/ctfer-io-bot) for publishing unwanted images.