### PR TITLE
ci: add nightly docker image

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,32 @@
+name: Nigthly Docker Build
+
+on:
+  schedule:
+    # Runs at 00:00 UTC every day
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: Dockerfile-nightly
+          push: true
+          tags: ctferio/ctfd:nightly

--- a/Dockerfile-nightly
+++ b/Dockerfile-nightly
@@ -1,0 +1,6 @@
+FROM ctfd/ctfd:latest
+
+USER root
+RUN apt update && apt install -y git
+RUN git clone https://github.com/ctfer-io/ctfd-chall-manager.git /opt/CTFd/CTFd/plugins/ctfd-chall-manager
+USER 1001


### PR DESCRIPTION
This PR add a `nightly` Docker image that use the latest version of CTFd and the main branch of the plugin.
:rotating_light:  **This image purpose is test only**, do not use it in production.