### PR TITLE
feat: add OpenTelemetry support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG CTFD_VERSION=3.7.5
+ARG CTFD_VERSION=3.7.7
 
 # Download the plugin
 FROM alpine:3.18 AS downloader
@@ -6,7 +6,7 @@ FROM alpine:3.18 AS downloader
 RUN apk update && \
     apk add --no-cache wget tar
 
-ARG PLUGIN_VERSION=0.2.0
+ARG PLUGIN_VERSION=0.4.1
 ENV PLUGIN_VERSION=${PLUGIN_VERSION}
 
 RUN mkdir /ctfd-chall-manager && \
@@ -17,3 +17,12 @@ RUN mkdir /ctfd-chall-manager && \
 FROM ctfd/ctfd:${CTFD_VERSION}
 RUN mkdir -p /opt/CTFd/CTFd/plugins/ctfd-chall-manager
 COPY --from=downloader /ctfd-chall-manager /opt/CTFd/CTFd/plugins/ctfd-chall-manager
+
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+RUN opentelemetry-bootstrap -a install
+
+USER root
+COPY docker-entrypoint.sh /opt/CTFd/docker-entrypoint.sh
+RUN chmod +x /opt/CTFd/docker-entrypoint.sh
+USER 1001

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+WORKERS=${WORKERS:-1}
+WORKER_CLASS=${WORKER_CLASS:-gevent}
+ACCESS_LOG=${ACCESS_LOG:--}
+ERROR_LOG=${ERROR_LOG:--}
+WORKER_TEMP_DIR=${WORKER_TEMP_DIR:-/dev/shm}
+SECRET_KEY=${SECRET_KEY:-}
+SKIP_DB_PING=${SKIP_DB_PING:-false}
+
+OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-"ctfd"}
+OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-""}
+OTEL_EXPORTER_OTLP_INSECURE=${OTEL_EXPORTER_OTLP_INSECURE:-"false"}
+
+# Check that a .ctfd_secret_key file or SECRET_KEY envvar is set
+if [ ! -f .ctfd_secret_key ] && [ -z "$SECRET_KEY" ]; then
+    if [ $WORKERS -gt 1 ]; then
+        echo "[ ERROR ] You are configured to use more than 1 worker."
+        echo "[ ERROR ] To do this, you must define the SECRET_KEY environment variable or create a .ctfd_secret_key file."
+        echo "[ ERROR ] Exiting..."
+        exit 1
+    fi
+fi
+
+# Skip db ping if SKIP_DB_PING is set to a value other than false or empty string
+if [[ "$SKIP_DB_PING" == "false" ]]; then
+  # Ensures that the database is available
+  python ping.py
+fi
+
+# Initialize database
+flask db upgrade
+
+if [[ "$OTEL_EXPORTER_OTLP_ENDPOINT" != "" ]]; then 
+    echo "Modifying CTFd for OTEL support..."
+
+    # This injects the monkey patch BEFORE auto-instrumentation, such there are no conflicts later
+    cat <<EOF > /tmp/__init__.py
+from gevent import monkey
+monkey.patch_all()
+
+from opentelemetry.instrumentation import auto_instrumentation
+auto_instrumentation.initialize()
+EOF
+    cat /opt/CTFd/CTFd/__init__.py >> /tmp/__init__.py
+    mv /tmp/__init__.py /opt/CTFd/CTFd/__init__.py
+
+    export OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME
+    export OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
+    export OTEL_EXPORTER_OTLP_INSECURE=$OTEL_EXPORTER_OTLP_INSECURE
+fi
+
+exec gunicorn 'CTFd:create_app()' \
+    --bind '0.0.0.0:8000' \
+    --workers $WORKERS \
+    --worker-tmp-dir "$WORKER_TEMP_DIR" \
+    --worker-class "$WORKER_CLASS" \
+    --access-logfile "$ACCESS_LOG" \
+    --error-logfile "$ERROR_LOG"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+opentelemetry-distro==0.55b1
+opentelemetry-exporter-otlp==1.34.1


### PR DESCRIPTION
This PR is a proposal to add CTFd within the OpenTelemetry support scope, in the CTFer.io infrastructures.
It was particularly difficult to set it up as we did not understood how CTFd was working under the hood with Flask/gunicorn/gevent and the OTEL auto-instrumentation.

First approach was to let the auto-instrumentation do its job, and even if it worked fine to get traces, it filled the logs with issues related to `gevent`'s monkey patches performed after the first import statements, possibly leading to inconsistencies.

Second approach is based upon [this work](http://github.com/builtwithdjango/builtwithdjango) and [this doc](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation#programmatic-auto-instrumentation).
When running with OpenTelemetry activated, the `CTFd/__init__.py` file is prepended the monkey patch then the OTEL auto-instrumentation. This maintains the projects' core rule "_do not change CTFd code, we won't do maintenance_" and reduce the cost of modifying every file calling `CTFd.create_app`: it's a deal/deal situation :tada:.
The `docker-entrypoint.sh`  is nonetheless a hard copy of CTFd's one, that we'll have to maintain (but I do not expect changes to happen often).

At the end of the day, there are no logs related to failures related to CTFd with OTEL, and traces can be explored (e.g. follows a Jaeger 2 screenshot).

<img width="905" height="553" alt="image" src="https://github.com/user-attachments/assets/4518f03f-0b79-4e23-a989-d4717944d1b1" />
