### PR TITLE
Update opentelemetry-distro and add `requests` instrumentation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-opentelemetry-distro==0.55b1
+opentelemetry-distro==0.57b0
 opentelemetry-exporter-otlp==1.34.1
+opentelemetry-instrumentation-requests==0.57b0


### PR DESCRIPTION
`requests`  is used to reach out Chall-Manager so is mandatory in order to build complete traces.
