### PR TITLE
chore: change plugins path since v0.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,17 @@ FROM alpine:3.18 AS downloader
 RUN apk update && \
     apk add --no-cache wget tar
 
-ARG PLUGIN_VERSION=0.4.1
+ARG PLUGIN_VERSION=0.6.0
 ENV PLUGIN_VERSION=${PLUGIN_VERSION}
 
-RUN mkdir /ctfd-chall-manager && \
+RUN mkdir /ctfd_chall_manager && \
     wget -qO- "https://github.com/ctfer-io/ctfd-chall-manager/releases/download/v${PLUGIN_VERSION}/ctfd-chall-manager_${PLUGIN_VERSION}.tar.gz" | \
-    tar -xz -C /ctfd-chall-manager
+    tar -xz -C /ctfd_chall_manager
 
 # Pre-package CTFd
 FROM ctfd/ctfd:${CTFD_VERSION}
-RUN mkdir -p /opt/CTFd/CTFd/plugins/ctfd-chall-manager
-COPY --from=downloader /ctfd-chall-manager /opt/CTFd/CTFd/plugins/ctfd-chall-manager
+RUN mkdir -p /opt/CTFd/CTFd/plugins/ctfd_chall_manager
+COPY --from=downloader /ctfd_chall_manager /opt/CTFd/CTFd/plugins/ctfd_chall_manager
 
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt

--- a/Dockerfile-nightly
+++ b/Dockerfile-nightly
@@ -2,7 +2,7 @@ FROM ctfd/ctfd:latest
 
 USER root
 RUN apt update && apt install -y git
-RUN git clone https://github.com/ctfer-io/ctfd-chall-manager.git /opt/CTFd/CTFd/plugins/ctfd-chall-manager
+RUN git clone https://github.com/ctfer-io/ctfd-chall-manager.git /opt/CTFd/CTFd/plugins/ctfd_chall_manager
 
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt


### PR DESCRIPTION
This PR changes the installation path of the plugin. 
This is a requirement since Python imports refactoring (more info [here](https://github.com/ctfer-io/ctfd-chall-manager/pull/181) and [here](https://github.com/ctfer-io/ctfd-chall-manager/issues/178)).

